### PR TITLE
fix: alter mastery calculation so its a bit more feasible and rewarding

### DIFF
--- a/app/components/Utils/masteryCalculation.ts
+++ b/app/components/Utils/masteryCalculation.ts
@@ -2,16 +2,23 @@ import { TrickState } from "./StorageService";
 import { TRICK_DATA } from "../Data/trickData";
 
 export function calculateSkateboardMastery(trickStates: TrickState): number {
-  const totalTricks = TRICK_DATA.length;
+  const includedTricks = TRICK_DATA.filter((trick) => {
+    const difficulty = Number(trick.difficulty);
+    return difficulty <= 10;
+  });
+
+  const totalTricks = includedTricks.length;
 
   const earnedPoints = Object.entries(trickStates).reduce(
     (total, [trickId, state]) => {
-      if (state === 2) {
+      const trick = includedTricks.find((t) => t.id === trickId);
+
+      if (!trick) return total;
+
+      if (state >= 1) {
         return total + 1;
       }
-      if (state === 1) {
-        return total + 0.5;
-      }
+
       return total;
     },
     0


### PR DESCRIPTION
i have left the statsbutton alone because if you get to the point where you are looking at the statsbutton, you care about really specific tricks rather than a general overview.

fix #134 